### PR TITLE
Fixes + External data functions added

### DIFF
--- a/libs/external-data/src/lib/adobe-analytics/index.ts
+++ b/libs/external-data/src/lib/adobe-analytics/index.ts
@@ -3,15 +3,21 @@ import utc from 'dayjs/plugin/utc';
 import { Overall, PageMetrics } from '@dua-upd/db';
 import { AnalyticsCoreAPI, getAAClient } from './client';
 import {
+  createActivityMapQuery,
   createCXTasksQuery,
-  createExamplePageBreakdownMetricsQuery,
+  createInternalSearchQuery,
   createOverallMetricsQuery,
   createPageMetricsQuery,
+  acquireActivityMapItemIdQuery,
+  acquireInternalSearchItemIdQuery,
+  createPhrasesSearchedOnPageQuery,
+  acquirePageUrlItemIdQuery,
+  createWhereVisitorsCameFromQuery,
 } from './queries';
 import { queryDateFormat, ReportSearch, ReportSettings } from './querybuilder';
 import { DateRange } from '../types';
 import { datesFromDateRange } from '../utils';
-import { wait } from '@dua-upd/utils-common';
+import { wait, sortArrayDesc, seperateArray } from '@dua-upd/utils-common';
 
 export * from './client';
 export * from './querybuilder';
@@ -202,15 +208,300 @@ export class AdobeAnalyticsClient {
     );
   }
 
-  async getExamplePageBreakdownMetrics(dateRange: DateRange): Promise<any[]> {
+  async acquirePageUrlItemId(
+    dateRange: DateRange,
+    options: ReportSettings = {}
+  ) {
     if (!this.client) {
       await this.initClient();
     }
 
-    const pageBreakdownMetricsQuery =
-      createExamplePageBreakdownMetricsQuery(dateRange);
-    const results = await this.client.getReport(pageBreakdownMetricsQuery);
+    options = {
+      limit: 50000,
+      ...options,
+    };
 
-    return results.body;
+    const acquirePageUrlItemId = acquirePageUrlItemIdQuery(
+      dateRange,
+      options
+    );
+    const results = await this.client.getReport(acquirePageUrlItemId);
+
+    const { columnIds } = results.body.columns;
+
+    //return results;
+
+    return results.body.rows.reduce((parsedResults, row) => {
+      // build up results object using columnIds as keys
+      const newPageMetricsData = row.data.reduce(
+        (rowValues, value, index) => {
+          const columnId = columnIds[index];
+          rowValues[columnId] = value;
+          return rowValues;
+        },
+        {
+          url: row.value,
+          pageurl_item_id: row.itemId,
+        }
+      );
+
+      return [...parsedResults, newPageMetricsData];
+    }, []);
+  }
+
+  async acquireActivityMapItemId(
+    dateRange: DateRange,
+    options: ReportSettings = {}
+  ) {
+    if (!this.client) {
+      await this.initClient();
+    }
+
+    options = {
+      limit: 50000,
+      ...options,
+    };
+
+    const acquireActivityMapItemId = acquireActivityMapItemIdQuery(
+      dateRange,
+      options
+    );
+    const results = await this.client.getReport(acquireActivityMapItemId);
+
+    const { columnIds } = results.body.columns;
+
+    //return results;
+
+    return results.body.rows.reduce((parsedResults, row) => {
+      // build up results object using columnIds as keys
+      const newPageMetricsData = row.data.reduce(
+        (rowValues, value, index) => {
+          const columnId = columnIds[index];
+          rowValues[columnId] = value;
+          return rowValues;
+        },
+        {
+          title: row.value,
+          activitymap_item_id: row.itemId,
+        }
+      );
+
+      return [...parsedResults, newPageMetricsData];
+    }, []);
+  }
+
+  async acquireInternalSearchItemId(
+    dateRange: DateRange,
+    options: ReportSettings = {}
+  ) {
+    if (!this.client) {
+      await this.initClient();
+    }
+
+    options = {
+      limit: 50000,
+      ...options,
+    };
+
+    const acquireInternalSearchItemId = acquireInternalSearchItemIdQuery(
+      dateRange,
+      options
+    );
+    const results = await this.client.getReport(acquireInternalSearchItemId);
+
+    const { columnIds } = results.body.columns;
+
+    //return results;
+
+    return results.body.rows.reduce((parsedResults, row) => {
+      // build up results object using columnIds as keys
+      const newPageMetricsData = row.data.reduce(
+        (rowValues, value, index) => {
+          const columnId = columnIds[index];
+          rowValues[columnId] = value;
+          return rowValues;
+        },
+        {
+          url: row.value,
+          internalsearch_item_id: row.itemId,
+        }
+      );
+
+      return [...parsedResults, newPageMetricsData];
+    }, []);
+  }
+
+  async getActivityMap(dateRange: DateRange, itemIds: string[], options: ReportSettings = {}) {
+    if (!this.client) {
+      await this.initClient();
+    }
+
+    options = {
+      limit: 50000,
+      ...options,
+    };
+
+    const activityMapQuery = createActivityMapQuery(dateRange, itemIds, options);
+    const results = await this.client.getReport(activityMapQuery);
+
+    const { columnIds } = results.body.columns;
+
+    // the 'Z' means the date is UTC, so no conversion required
+    const date = new Date(dateRange.start + 'Z');
+
+    //return results;
+
+    return sortArrayDesc(seperateArray(results.body.rows))
+      .map((row) => {
+        return row.map((v) => {
+          return {
+            link: v.value,
+            clicks: v.data,
+          };
+        });
+      })
+      .reduce(
+        (rowValues, value, index) => {
+          const columnId = columnIds[index];
+          rowValues[columnId] = value;
+          return rowValues;
+        },
+        { date } as any
+      );
+  }
+
+  async getWhereVisitorsCameFrom(dateRange: DateRange, itemIds: string[], options: ReportSettings = {}) {
+    if (!this.client) {
+      await this.initClient();
+    }
+
+    options = {
+      limit: 50000,
+      ...options,
+    };
+
+    const whereVisitorsCameFromQuery = createWhereVisitorsCameFromQuery(dateRange, itemIds, options);
+    const results = await this.client.getReport(whereVisitorsCameFromQuery);
+
+    const { columnIds } = results.body.columns;
+
+    // the 'Z' means the date is UTC, so no conversion required
+    const date = new Date(dateRange.start + 'Z');
+
+    //return results;
+
+    return sortArrayDesc(seperateArray(results.body.rows))
+      .map((row) => {
+        return row.map((v) => {
+          return {
+            link: v.value,
+            visits: v.data,
+          };
+        });
+      })
+      .reduce(
+        (rowValues, value, index) => {
+          const columnId = columnIds[index];
+          rowValues[columnId] = value;
+          return rowValues;
+        },
+        { date } as any
+      );
+  }
+
+  async getInternalSearches(
+    dateRange: DateRange,
+    itemIds: string[],
+    options: ReportSettings = {}
+  ) {
+    if (!this.client) {
+      await this.initClient();
+    }
+
+    options = {
+      limit: 50000,
+      page: 0,
+      ...options,
+    };
+
+    const internalSearchQuery = createInternalSearchQuery(
+      dateRange,
+      itemIds,
+      options
+    );
+    const results = await this.client.getReport(internalSearchQuery);
+
+    const { columnIds } = results.body.columns;
+
+    // the 'Z' means the date is UTC, so no conversion required
+    const date = new Date(dateRange.start + 'Z');
+
+    //return results;
+
+    return sortArrayDesc(seperateArray(results.body.rows))
+      .map((row) => {
+        return row.map((v) => {
+          return {
+            phrase: v.value,
+            clicks: v.data,
+          };
+        });
+      })
+      .reduce(
+        (rowValues, value, index) => {
+          const columnId = columnIds[index];
+          rowValues[columnId] = value;
+          return rowValues;
+        },
+        { date } as any
+      );
+  }
+
+  async getPhrasesSearchedOnPage(
+    dateRange: DateRange,
+    itemIds: string[],
+    options: ReportSettings = {}
+  ) {
+    if (!this.client) {
+      await this.initClient();
+    }
+
+    options = {
+      limit: 50000,
+      page: 0,
+      ...options,
+    };
+
+    const internalSearchQuery = createPhrasesSearchedOnPageQuery(
+      dateRange,
+      itemIds,
+      options
+    );
+    const results = await this.client.getReport(internalSearchQuery);
+
+    const { columnIds } = results.body.columns;
+
+    // the 'Z' means the date is UTC, so no conversion required
+    const date = new Date(dateRange.start + 'Z');
+
+    //return results;
+
+    return sortArrayDesc(seperateArray(results.body.rows))
+      .map((row) => {
+        return row.map((v) => {
+          return {
+            phrase: v.value,
+            clicks: v.data,
+          };
+        });
+      })
+      .reduce(
+        (rowValues, value, index) => {
+          const columnId = columnIds[index];
+          rowValues[columnId] = value;
+          return rowValues;
+        },
+        { date } as any
+      );
   }
 }

--- a/libs/external-data/src/lib/adobe-analytics/queries.ts
+++ b/libs/external-data/src/lib/adobe-analytics/queries.ts
@@ -20,6 +20,10 @@ export const overallMetricsQueryConfig: MetricsConfig = {
   rap_initiated: 'metrics/event73',
   rap_completed: 'metrics/event75',
   nav_menu_initiated: 'metrics/event69',
+  // reloads: 'metrics/reloads',
+  // single_page_visits: 'metrics/singlepagevisits',
+  // entries: 'metrics/entries',
+  // exits: 'metrics/exits',
   rap_cant_find: CALCULATED_METRICS.RAP_CANT_FIND,
   rap_login_error: CALCULATED_METRICS.RAP_LOGIN_ERROR,
   rap_other: CALCULATED_METRICS.RAP_OTHER,
@@ -61,6 +65,16 @@ export const overallMetricsQueryConfig: MetricsConfig = {
   visits_device_desktop: CALCULATED_METRICS.DEVICES_DESKTOP,
   visits_device_mobile: CALCULATED_METRICS.DEVICES_MOBILE,
   visits_device_tablet: CALCULATED_METRICS.DEVICES_TABLET,
+  // time_less_than_15_sec: CALCULATED_METRICS.TIME_LESSTHAN15SEC,
+  // time_15_to_29_sec: CALCULATED_METRICS.TIME_15TO29SEC,
+  // time_30_to_59_sec: CALCULATED_METRICS.TIME_30TO59SEC,
+  // time_1_to_3_min: CALCULATED_METRICS.TIME_1TO3MIN,
+  // time_3_to_5_min: CALCULATED_METRICS.TIME_3TO5MIN,
+  // time_5_to_10_min: CALCULATED_METRICS.TIME_5TO10MIN,
+  // time_10_to_15_min: CALCULATED_METRICS.TIME_10TO15MIN,
+  // time_15_to_20_min: CALCULATED_METRICS.TIME_15TO20MIN,
+  // time_20_to_30_min: CALCULATED_METRICS.TIME_20TO30MIN,
+  // time_more_than_30_min: CALCULATED_METRICS.TIME_MORETHAN30MIN,
 };
 
 export const createOverallMetricsQuery = (
@@ -139,34 +153,209 @@ export const createCXTasksQuery = (
 };
 
 // todo: just an example for now - should be made to take an array of pages/itemIds and set filters and stuff accordingly
-export const createExamplePageBreakdownMetricsQuery = (
-  dateRange: DateRange
+export const createActivityMapQuery = (
+  dateRange: DateRange,
+  itemIds: string[],
+  settings: ReportSettings = {}
 ) => {
   const queryBuilder = new AdobeAnalyticsQueryBuilder();
 
+  const querySettings = {
+    nonesBehavior: 'return-nones',
+    countRepeatInstances: true,
+    ...settings,
+  };
+
   return queryBuilder
-    .setDimension('variables/evar50') // Site search
+    .setDimension('variables/clickmaplink') // Site search
     .setMetrics({
-      searchesFromPage: {
-        id: 'metrics/event51',
+      activityMap: {
+        id: 'metrics/clickmaplinkinstances',
         filters: [
           {
-            id: 'firstPage',
+            itemIds: itemIds,
             type: 'breakdown',
-            dimension: 'variables/evar19', // prev page url
-            itemId: '4116743888',
+            dimension: 'variables/clickmappage',
           },
         ],
       },
     })
     .setGlobalFilters([
+      { type: 'dateRange', dateRange: `${dateRange.start}/${dateRange.end}` },
+    ])
+    .setSettings(querySettings)
+    .build();
+};
+
+export const createInternalSearchQuery = (
+  dateRange: DateRange,
+  itemids: string[],
+  settings: ReportSettings = {}
+) => {
+  const queryBuilder = new AdobeAnalyticsQueryBuilder();
+
+  const querySettings = {
+    nonesBehavior: 'return-nones',
+    countRepeatInstances: true,
+    ...settings,
+  };
+
+  return queryBuilder
+    .setDimension('variables/evar50') // Site search
+    .setMetrics({
+      activityMap: {
+        id: 'metrics/event51',
+        filters: [
+          {
+            itemIds: itemids,
+            type: 'breakdown',
+            dimension: 'variables/evar52',
+          },
+        ],
+      },
+    })
+    .setGlobalFilters([
+      { type: 'dateRange', dateRange: `${dateRange.start}/${dateRange.end}` },
+    ])
+    .setSettings(querySettings)
+    .build();
+};
+
+export const createPhrasesSearchedOnPageQuery = (
+  dateRange: DateRange,
+  itemids: string[],
+  settings: ReportSettings = {}
+) => {
+  const queryBuilder = new AdobeAnalyticsQueryBuilder();
+
+  const querySettings = {
+    nonesBehavior: 'return-nones',
+    countRepeatInstances: true,
+    ...settings,
+  };
+
+  return queryBuilder
+    .setDimension('variables/evar50') // Site search
+    .setMetrics({
+      activityMap: {
+        id: 'metrics/event50',
+        filters: [
+          {
+            itemIds: itemids,
+            type: 'breakdown',
+            dimension: 'variables/evar19',
+          },
+        ],
+      },
+    })
+    .setGlobalFilters([
+      { type: 'segment', segmentId: SEGMENTS.CRA_SEARCH_PAGES },
+      { type: 'dateRange', dateRange: `${dateRange.start}/${dateRange.end}` },
+    ])
+    .setSettings(querySettings)
+    .build();
+};
+
+export const createWhereVisitorsCameFromQuery = (
+  dateRange: DateRange,
+  itemids: string[],
+  settings: ReportSettings = {}
+) => {
+  const queryBuilder = new AdobeAnalyticsQueryBuilder();
+
+  const querySettings = {
+    nonesBehavior: 'return-nones',
+    countRepeatInstances: true,
+    ...settings,
+  };
+
+  return queryBuilder
+    .setDimension('variables/evar19') // Site search
+    .setMetrics({
+      activityMap: {
+        id: 'metrics/visits',
+        filters: [
+          {
+            itemIds: itemids,
+            type: 'breakdown',
+            dimension: 'variables/evar22',
+          },
+        ],
+      },
+    })
+    .setGlobalFilters([
+      { type: 'dateRange', dateRange: `${dateRange.start}/${dateRange.end}` },
+    ])
+    .setSettings(querySettings)
+    .build();
+};
+
+// todo: just an example for now - should be made to take an array of pages/itemIds and set filters and stuff accordingly
+export const acquireActivityMapItemIdQuery = (
+  dateRange: DateRange,
+  settings: ReportSettings = {}
+) => {
+  const queryBuilder = new AdobeAnalyticsQueryBuilder();
+
+  const querySettings = {
+    nonesBehavior: 'return-nones',
+    countRepeatInstances: true,
+    ...settings,
+  };
+
+   return queryBuilder
+    .setDimension('variables/clickmappage') // Site search
+    .setMetrics({ visits: 'metrics/clickmaplinkinstances' } as MetricsConfig)
+    .setGlobalFilters([
       { type: 'segment', segmentId: SEGMENTS.cra },
       { type: 'dateRange', dateRange: `${dateRange.start}/${dateRange.end}` },
     ])
-    .setSettings({
-      nonesBehavior: 'return-nones',
-      countRepeatInstances: true,
-      limit: 25,
-    })
+    .setSettings(querySettings)
+    .build();
+};
+
+export const acquireInternalSearchItemIdQuery = (
+  dateRange: DateRange,
+  settings: ReportSettings = {}
+) => {
+  const queryBuilder = new AdobeAnalyticsQueryBuilder();
+
+  const querySettings = {
+    nonesBehavior: 'return-nones',
+    countRepeatInstances: true,
+    ...settings,
+  };
+
+  return queryBuilder
+    .setDimension('variables/evar52') // Site search
+    .setMetrics({ visits: 'metrics/event51' } as MetricsConfig)
+    .setGlobalFilters([
+      { type: 'segment', segmentId: SEGMENTS.cra },
+      { type: 'dateRange', dateRange: `${dateRange.start}/${dateRange.end}` },
+    ])
+    .setSettings(querySettings)
+    .build();
+};
+
+export const acquirePageUrlItemIdQuery = (
+  dateRange: DateRange,
+  settings: ReportSettings = {}
+) => {
+  const queryBuilder = new AdobeAnalyticsQueryBuilder();
+
+  const querySettings = {
+    nonesBehavior: 'return-nones',
+    countRepeatInstances: true,
+    ...settings,
+  };
+
+  return queryBuilder
+    .setDimension('variables/evar22') // Site search
+    .setMetrics({ visits: 'metrics/visits' } as MetricsConfig)
+    .setGlobalFilters([
+      { type: 'segment', segmentId: SEGMENTS.cra },
+      { type: 'dateRange', dateRange: `${dateRange.start}/${dateRange.end}` },
+    ])
+    .setSettings(querySettings)
     .build();
 };

--- a/libs/external-data/src/lib/external-data.spec.ts
+++ b/libs/external-data/src/lib/external-data.spec.ts
@@ -26,7 +26,9 @@ describe('getPageMetrics', () => {
       end: toQueryFormat('2022-01-02'),
     };
 
-    const results = await client.getPageMetrics(dateRange, { settings: { limit: 25 } });
+    const results = await client.getPageMetrics(dateRange, {
+      settings: { limit: 25 },
+    });
 
     console.log(results);
 
@@ -43,17 +45,15 @@ describe('new AA fields', () => {
       end: dayjs('2022-01-02').format(queryDateFormat),
     };
     const results = await client.getOverallMetrics(dateRange);
-
     console.log(results);
-
     expect(results).toBeDefined();
-  })
+  });
 });
 
 describe('externalData', () => {
   const dateRange = {
-    start: toQueryFormat('2022-01-01'),
-    end: toQueryFormat('2022-01-02'),
+    start: toQueryFormat('2022-06-01'),
+    end: toQueryFormat('2022-06-02'),
   };
 
   it('should be able to initalize the query builder', async () => {
@@ -77,8 +77,9 @@ describe('externalData', () => {
         },
       ])
       .setSearch({
-        clause: '( CONTAINS \'www.canada.ca/en/revenue-agency/services/e-services/cra-login-services.html\' )'
-        + ' OR ( CONTAINS \'www.canada.ca/en/revenue-agency/services/e-services/represent-a-client.html\' )'
+        clause:
+          "( CONTAINS 'www.canada.ca/en/revenue-agency/services/e-services/cra-login-services.html' )" +
+          " OR ( CONTAINS 'www.canada.ca/en/revenue-agency/services/e-services/represent-a-client.html' )",
       })
       .setSettings({ limit: 10 })
       .build();
@@ -86,11 +87,88 @@ describe('externalData', () => {
     expect(query).toBeDefined();
   });
 
-  it('should be able to get overall metrics', async () => {
-    const client = new AdobeAnalyticsClient()
-    const results = await client.getOverallMetrics(dateRange);
 
-    expect(results).toBeDefined();
+  it('should be able to get phrases users searched on from page', async () => {
+    const client = new AdobeAnalyticsClient();
+
+    const results = await client.acquireInternalSearchItemId(dateRange);
+    const array: string[] = [];
+
+    results.forEach((result) => {
+      array.push(result.internalsearch_item_id);
+    });
+
+    console.log(array.length);
+
+    const results2 = await client.getPhrasesSearchedOnPage(
+      dateRange,
+      array.slice(0, 333)
+    );
+    console.log(results2);
+
+    expect(results2).toBeDefined();
+  });
+  it('should be able to get where visitors came from', async () => {
+    const client = new AdobeAnalyticsClient();
+
+    const results = await client.acquirePageUrlItemId(dateRange)
+    const array: string[] = [];
+
+    results.forEach((result) => {
+      array.push(result.pageurl_item_id);
+    });
+
+    console.log(array.length);
+
+    const results2 = await client.getWhereVisitorsCameFrom(
+      dateRange,
+      array.slice(0, 1000)
+    );
+    console.log(results2);
+
+    expect(results2).toBeDefined();
+  });
+  
+  it('should be able to get internal searches', async () => {
+    const client = new AdobeAnalyticsClient();
+
+    const results = await client.acquireInternalSearchItemId(dateRange);
+    const array: string[] = [];
+
+    results.forEach((result) => {
+      array.push(result.internalsearch_item_id);
+    });
+
+    console.log(array.length);
+
+    const results2 = await client.getInternalSearches(
+      dateRange,
+      array.slice(0, 333)
+    );
+    console.log(results2);
+
+    expect(results2).toBeDefined();
+  });
+
+  it('should be able to get activity map', async () => {
+    const client = new AdobeAnalyticsClient();
+
+    const results = await client.acquireActivityMapItemId(dateRange);
+    const array: string[] = [];
+
+    results.forEach((result) => {
+      array.push(result.activitymap_item_id);
+    });
+
+    console.log(array.length);
+
+    const results2 = await client.getActivityMap(
+      dateRange,
+      array.slice(0, 1000)
+    );
+    console.log(results2);
+
+    expect(results2).toBeDefined();
   });
 });
 
@@ -109,34 +187,42 @@ describe('Google Search Console', () => {
         dimensions: ['date', 'query'],
         dimensionFilterGroups: [
           {
-            filters: [{
-              dimension: 'page',
-              operator: 'equals',
-              expression: 'https://www.canada.ca/en/services/taxes.html',
-            }]
-          }
+            filters: [
+              {
+                dimension: 'page',
+                operator: 'equals',
+                expression: 'https://www.canada.ca/en/services/taxes.html',
+              },
+            ],
+          },
         ],
         startDate: '2022-01-01',
         endDate: '2022-01-02',
-      }
+      },
     });
 
     expect(results.data.rows).toBeDefined();
-  })
+  });
 
   it('should be able to get results for GSC overall metrics for all CRA-related pages', async () => {
     const client = new SearchAnalyticsClient();
-    const results = await client.getOverallMetrics({ start: '2022-01-16', end: '2022-01-16' });
+    const results = await client.getOverallMetrics({
+      start: '2022-01-16',
+      end: '2022-01-16',
+    });
 
     expect(results).toBeDefined();
-  })
+  });
 
   it('should be able to get results for GSC search terms for all CRA-related pages', async () => {
     const client = new SearchAnalyticsClient();
-    const results = await client.getPageMetrics({ start: '2022-01-16', end: '2022-01-16' });
+    const results = await client.getPageMetrics({
+      start: '2022-01-16',
+      end: '2022-01-16',
+    });
 
     expect(results).toBeDefined();
-  })
+  });
 
   it('should be able to get results for fresh data', async () => {
     const results = await gscClient.searchanalytics.query({
@@ -145,22 +231,24 @@ describe('Google Search Console', () => {
         dimensions: ['date', 'query'],
         dimensionFilterGroups: [
           {
-            filters: [{
-              dimension: 'page',
-              operator: 'equals',
-              expression: 'https://www.canada.ca/en/services/taxes.html',
-            }]
-          }
+            filters: [
+              {
+                dimension: 'page',
+                operator: 'equals',
+                expression: 'https://www.canada.ca/en/services/taxes.html',
+              },
+            ],
+          },
         ],
         startDate: dayjs().subtract(1, 'day').format('YYYY-MM-DD'),
         endDate: dayjs().subtract(1, 'day').format('YYYY-MM-DD'),
         dataState: 'all',
-      }
+      },
     });
     console.log(results.data.rows);
 
     expect(results.data.rows).toBeDefined();
-  })
+  });
 
   it('should be able to get results for a regex', async () => {
     const results = await gscClient.searchanalytics.query({
@@ -169,23 +257,25 @@ describe('Google Search Console', () => {
         dimensions: ['date', 'query', 'page'],
         dimensionFilterGroups: [
           {
-            filters: [{
-              dimension: 'page',
-              operator: 'includingRegex',
-              expression: '/en/revenue-agency|/fr/agence-revenu|/en/services/taxes|/fr/services/impots',
-            }]
-          }
+            filters: [
+              {
+                dimension: 'page',
+                operator: 'includingRegex',
+                expression:
+                  '/en/revenue-agency|/fr/agence-revenu|/en/services/taxes|/fr/services/impots',
+              },
+            ],
+          },
         ],
         startDate: dayjs().subtract(1, 'day').format('YYYY-MM-DD'),
         endDate: dayjs().subtract(1, 'day').format('YYYY-MM-DD'),
         dataState: 'all',
-      }
+      },
     });
 
     expect(results.data.rows).toBeDefined();
-  })
-
-})
+  });
+});
 
 describe('AirTable', () => {
   it('should initialise the client', async () => {

--- a/libs/utils-common/src/lib/data/index.ts
+++ b/libs/utils-common/src/lib/data/index.ts
@@ -8,6 +8,10 @@ import { dateRangeSplit } from '../date';
  */
 export const getLatestTest = (uxTests: Partial<UxTest>[]) =>
   uxTests.reduce((latestTest, test) => {
+    if (test.success_rate) {
+      return test;
+    }
+
     if (!latestTest || typeof latestTest?.date !== 'object') {
       return test;
     }
@@ -36,7 +40,7 @@ export function getAvgTestSuccess(uxTests: Partial<UxTest>[]) {
       testsWithSuccessRate.reduce(
         (total, success_rate) => total + success_rate,
         0
-      ) / uxTests.length
+      ) / testsWithSuccessRate.length
     );
   }
 

--- a/libs/utils-common/src/lib/utils-common.d.ts
+++ b/libs/utils-common/src/lib/utils-common.d.ts
@@ -1,3 +1,12 @@
 export declare function wait(ms: number): Promise<unknown>;
 export declare function squishTrim(str: string | void): string | void;
-export declare function LogTiming(message?: string): (target: object, name: string, descriptor: PropertyDescriptor) => void;
+export declare function LogTiming(
+  message?: string
+): (target: object, name: string, descriptor: PropertyDescriptor) => void;
+export declare function getArraySeperated(arr: {
+  data: number[];
+  value: string;
+}): { data: number; value: string }[][];
+export declare function sortArrayDesc(
+  arr: { data: number; value: string }[][]
+): { data: number; value: string }[][];

--- a/libs/utils-common/src/lib/utils-common.ts
+++ b/libs/utils-common/src/lib/utils-common.ts
@@ -29,3 +29,49 @@ export function LogTiming(message = '') {
     };
   };
 }
+
+/**
+ * It takes an array of objects from AA, and returns an array of arrays, where each array is a group of objects
+ * @param {{ data: number[]; value: string }[]} arr - The array of objects that you want to seperate.
+ * @returns An array of arrays of objects.
+ */
+export function seperateArray(arr: { data: number[]; value: string }[]) {
+  const newArrays: { data: number; value: string }[][] = [];
+
+  for (let i = 0; i < arr.length; i++) {
+    const current_row = arr[i];
+    for (let j = 0; j < current_row.data.length; j++) {
+      const current_data = current_row.data[j];
+
+      if (newArrays[j] === undefined) {
+        newArrays[j] = [];
+      }
+
+      if (current_data === 0) {
+        continue;
+      }
+
+      newArrays[j].push({
+        data: current_data,
+        value: current_row.value,
+      });
+    }
+  }
+
+  return newArrays;
+}
+
+/**
+ * It sorts an array of arrays of objects by the data property in descending order
+ * @param {{ data: number; value: string }[][]} arr - The array to be sorted.
+ * @returns the sorted array.
+ */
+export function sortArrayDesc(arr: { data: number; value: string }[][]) {
+  arr.forEach((e) => {
+    e.sort((a, b) => {
+      return b.data - a.data;
+    });
+  });
+
+  return arr;
+}


### PR DESCRIPTION
- Fixed the latest date, bug occurred if success_rate is empty, it would show 0 regardless
- Added functionality in external data for acquiring itemids for url (first 255 characters), last 255 chars, and page title for activity map.
- Also added the get functions for the appropriate dimensions (check external data spec for a how to)
- Added time spent on page bucketed calcuated metrics + others (commented out for now)