### PR TITLE
Added missing translations to fix "hardcoded" translations issue

### DIFF
--- a/libs/upd/i18n/src/lib/translations/en-CA.json
+++ b/libs/upd/i18n/src/lib/translations/en-CA.json
@@ -101,6 +101,8 @@
   "d3-BE": "Business Enquiries (BE)",
   "d3-C4 - Identity Theft": "C4 - Identity Theft",
   "d3-C9 - My Account Lockout": "C9 - My Account Lockout",
+  "d3-Canada Housing Benefit": "Canada Housing Benefit",
+  "d3-C9 - Dental": "C9 - Dental",
   "call-drivers-disclaimer": "This report presents call topic results for the main agent queues based on a random sample of calls.",
   "top10-pages-visited": "Top 10 pages visited",
   "comment": "Comment",

--- a/libs/upd/i18n/src/lib/translations/fr-CA.json
+++ b/libs/upd/i18n/src/lib/translations/fr-CA.json
@@ -101,6 +101,8 @@
   "d3-BE": "Demande de renseignements aux entreprises (DRE)",
   "d3-C4 - Identity Theft": "C4 - Vol d'identité",
   "d3-C9 - My Account Lockout": "C9 - Verrouillage de mon compte",
+  "d3-Canada Housing Benefit": "Allocation canadienne pour le logement",
+  "d3-C9 - Dental": "C9 - Dentaire",
   "call-drivers-disclaimer": "Ce rapport présente les résultats des sujets d'appel pour les principales files d'attente d'agents sur la base d'un échantillon aléatoire d'appels.",
   "top10-pages-visited": "Dix pages les plus visitées",
   "comment": "Commenter",


### PR DESCRIPTION
There are missing translations in the en-CA and fr-CA json files so the string would show the "d3-".  Added the missing translations to fix this issue.