### PR TITLE
Fixed success rate average calculation

### DIFF
--- a/libs/upd/i18n/src/lib/translations/en-CA.json
+++ b/libs/upd/i18n/src/lib/translations/en-CA.json
@@ -237,7 +237,7 @@
   "Latest success rate": "Latest success rate",
   "Total participants from all tests": "Total participants from all tests",
   "Tasks success by Test": "Tasks success by Test",
-  "Tasks success by test": "Tasks success by test",
+  "Average tasks success by test": "Average tasks success by test",
   "Success rate and scenarios": "Success rate and scenarios",
   "Documents": "Documents",
   "Task success rate (%)": "Task success rate (%)",

--- a/libs/upd/i18n/src/lib/translations/fr-CA.json
+++ b/libs/upd/i18n/src/lib/translations/fr-CA.json
@@ -237,7 +237,7 @@
   "Latest success rate": "Dernier taux de réussite",
   "Total participants from all tests": "Nombre total de participants à tous les tests",
   "Tasks success by Test": "Succès des tâches par test",
-  "Tasks success by test": "Succès des tâches par test",
+  "Average tasks success by test": "Succès moyenne des tâches par test",
   "Success rate and scenarios": "Taux de réussite et scénarios",
   "Documents": "Documents",
   "Task success rate (%)": "Taux de réussite des tâches (%)",

--- a/libs/upd/views/projects/src/lib/project-details/+state/projects-details.facade.ts
+++ b/libs/upd/views/projects/src/lib/project-details/+state/projects-details.facade.ts
@@ -483,9 +483,7 @@ export class ProjectsDetailsFacade {
     this.currentLang$,
   ]).pipe(
     map(([data, lang]) => {
-      const uxTests = data?.taskSuccessByUxTest.filter(
-        (uxTest) => uxTest.success_rate ?? false
-      );
+      const uxTests = data?.taskSuccessByUxTest;
 
       const tasksWithSuccessRate = uxTests
         ?.map((uxTest) => uxTest.tasks.split('; ') || [])

--- a/libs/upd/views/projects/src/lib/project-details/+state/projects-details.facade.ts
+++ b/libs/upd/views/projects/src/lib/project-details/+state/projects-details.facade.ts
@@ -484,7 +484,7 @@ export class ProjectsDetailsFacade {
   ]).pipe(
     map(([data, lang]) => {
       const uxTests = data?.taskSuccessByUxTest.filter(
-        (uxTest) => uxTest.success_rate !== undefined
+        (uxTest) => uxTest.success_rate || uxTest.success_rate === 0
       );
 
       const tasksWithSuccessRate = uxTests

--- a/libs/upd/views/projects/src/lib/project-details/+state/projects-details.facade.ts
+++ b/libs/upd/views/projects/src/lib/project-details/+state/projects-details.facade.ts
@@ -483,7 +483,9 @@ export class ProjectsDetailsFacade {
     this.currentLang$,
   ]).pipe(
     map(([data, lang]) => {
-      const uxTests = data?.taskSuccessByUxTest;
+      const uxTests = data?.taskSuccessByUxTest.filter(
+        (uxTest) => uxTest.success_rate !== undefined
+      );
 
       const tasksWithSuccessRate = uxTests
         ?.map((uxTest) => uxTest.tasks.split('; ') || [])


### PR DESCRIPTION
Average success rate was not being properly calculated for the graph when a UX test success rate is 0. UX Tests were filtered based on if the success rate was null/undefined or not. As a result, a success rate that is 0 was not used in the calculation. Modified the filter to fix this calculation issue. Also added "average" in the title for "Tasks success by test" and "Task success by UX test".