### PR TITLE
Double default maxWidth setting for apexcharts

### DIFF
--- a/libs/upd/components/src/lib/apex-base/apex.config.base.ts
+++ b/libs/upd/components/src/lib/apex-base/apex.config.base.ts
@@ -80,6 +80,7 @@ export const createBaseConfig = (formatter: (val: number) => string) => ({
       style: {
         fontSize: '14px',
       },
+      maxWidth: 320,
       formatter,
     },
     title: {


### PR DESCRIPTION
Default maxWidth setting for apexcharts labels is 160 if unspecified. The maxWidth setting is now set to 320