### PR TITLE
fix: Avoid validation error when inserting GC TSS documents by making…

### DIFF
--- a/libs/db/src/lib/schemas/gc-tasks.schema.ts
+++ b/libs/db/src/lib/schemas/gc-tasks.schema.ts
@@ -33,7 +33,7 @@ export class GcTasks implements IGCTasks {
   @Prop({ type: String, required: true })
   department: string;
 
-  @Prop({ type: String, required: true })
+  @Prop({ type: String })
   theme: string;
 
   @Prop({ type: String })


### PR DESCRIPTION
… the `theme` property optional