### PR TITLE
Fix date format to use lowercase 'yyyy' in date pipe parameters to…

### DIFF
--- a/libs/upd/components/src/lib/data-table-exports/data-table-exports.component.ts
+++ b/libs/upd/components/src/lib/data-table-exports/data-table-exports.component.ts
@@ -126,7 +126,7 @@ export class DataTableExportsComponent<T> {
           } else if (col.pipe === 'date') {
             formattedRow[colKey] = formatDate(
               (<unknown>cellValue) as Date,
-              col.pipeParam ?? 'YYYY-MM-dd',
+              col.pipeParam ?? 'yyyy-MM-dd',
               currentLang,
               'UTC',
             );

--- a/libs/upd/components/src/lib/data-table-styles/data-table-styles.component.ts
+++ b/libs/upd/components/src/lib/data-table-styles/data-table-styles.component.ts
@@ -120,7 +120,7 @@ export class DataTableStylesComponent implements OnInit {
         return (
           formatDate(
             data,
-            effectivePipeParam ?? 'YYYY-MM-dd',
+            effectivePipeParam ?? 'yyyy-MM-dd',
             this.currentLang,
             'UTC',
           ) || ''

--- a/libs/upd/views/overview/src/lib/overview-ux-tests/overview-ux-tests.component.ts
+++ b/libs/upd/views/overview/src/lib/overview-ux-tests/overview-ux-tests.component.ts
@@ -111,7 +111,7 @@ export class OverviewUxTestsComponent implements OnInit {
           field: 'startDate',
           header: this.i18n.service.translate('Start date', lang),
           pipe: 'date',
-          pipeParam: lang === FR_CA ? 'd MMM YYYY' : 'MMM dd, YYYY',
+          pipeParam: lang === FR_CA ? 'd MMM yyyy' : 'MMM dd, yyyy',
         },
         {
           field: 'lastAvgSuccessRate',

--- a/libs/upd/views/projects/src/lib/projects-home/projects-home.component.ts
+++ b/libs/upd/views/projects/src/lib/projects-home/projects-home.component.ts
@@ -71,7 +71,7 @@ export class ProjectsHomeComponent implements OnInit {
             field: 'startDate',
             header: this.i18n.service.translate('Start date', lang),
             pipe: 'date',
-            pipeParam: lang === FR_CA ? 'd MMM YYYY' : 'MMM dd, YYYY',
+            pipeParam: lang === FR_CA ? 'd MMM yyyy' : 'MMM dd, yyyy',
           },
           {
             field: 'lastAvgSuccessRate',

--- a/libs/upd/views/reports/src/lib/+state/reports.facade.ts
+++ b/libs/upd/views/reports/src/lib/+state/reports.facade.ts
@@ -124,7 +124,7 @@ export class ReportsFacade {
           field: 'startDate',
           header: this.i18n.service.translate('Start date', lang),
           pipe: 'date',
-          pipeParam: lang === FR_CA ? 'd MMM YYYY' : 'MMM dd, YYYY',
+          pipeParam: lang === FR_CA ? 'd MMM yyyy' : 'MMM dd, yyyy',
         },
         // {
         //   field: 'lastAvgSuccessRate',


### PR DESCRIPTION
…avoid `formatDate` bug causing wrong year